### PR TITLE
Car 3079 cache build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - run: npx semantic-release -d
+      - run: npx semantic-release
       - notify_slack_failure
 
 workflows:
@@ -112,5 +112,5 @@ workflows:
           filters:
             branches:
               only:
-                - CAR-3079-cache-build
+                - master
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     ]
   },
   "release": {
-    "branch": "CAR-3079-cache-build",
     "pkgRoot": "pkg"
   }
 }


### PR DESCRIPTION
- Updated version is original `package.json`
- Added caching of build (I did not add the full path to the pkg folder so we do not have to maintain it in case it changes)
- Did some tryouts to see if everything works
- Adde slack failure notifications to all jobs

Things to consider:

Now the release is restricted to the master branch by circleci and semantic-release (so we will have to maintain it in both locations if it should change). Nevertheless, this has the advantage of not triggering an additional Job on the CI on other branches.