### PR TITLE
rename test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "lint": "tslint --project tsconfig.lint.json",
     "format": "tslint --project tsconfig.lint.json --fix",
     "typecheck": "tsc --noEmit",
-    "test:unit": "jest",
-    "test:unit:debug": "node --inspect-brk --inspect=127.0.0.1:9229 ./node_modules/jest/bin/jest.js --runInBand"
+    "test": "jest",
+    "test:debug": "node --inspect-brk --inspect=127.0.0.1:9229 ./node_modules/jest/bin/jest.js --runInBand"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
there is only one type of tests, so let's make it the default. this is in line with the listings app too