### PR TITLE
fix: add publishConfig to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "tslint": "^5.20.1",
     "typescript": "^3.7.4"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "@pika/pack": {
     "pipeline": [
       [


### PR DESCRIPTION
This configuration is responsible for publishing a public package on npm.
Otherwise, the package is private by default.